### PR TITLE
Añadir imagen de LaLiga y actualizar referencia

### DIFF
--- a/public/laliga.svg
+++ b/public/laliga.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="45" fill="#f50000"/>
+  <text x="50" y="55" font-size="20" text-anchor="middle" fill="#ffffff" font-family="Arial">LaLiga</text>
+</svg>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,6 +6,7 @@ import { TrendingUp, Target, Award, Star, BarChart3, Users } from "lucide-react"
 const heroImage = "/hero-betting.svg";
 const sportsAnalystsImage = "/sports-analysts-team.svg";
 const profitImage = "/profit-success.svg";
+const laligaImage = "/laliga.svg";
 
 const Index = () => {
   const handleSubscribe = (plan: string) => {
@@ -274,8 +275,8 @@ const Index = () => {
             </div>
             <div className="relative">
               <div className="absolute inset-0 bg-gradient-hero opacity-20 rounded-2xl blur-xl"></div>
-              <img 
-                src="/lovable-uploads/1e8886c8-7460-4413-a635-f23de612bf8a.png" 
+              <img
+                src={laligaImage}
                 alt="Liga Española de Fútbol - Especialización en pronósticos deportivos"
                 className="relative rounded-2xl shadow-card w-full h-auto"
               />


### PR DESCRIPTION
## Summary
- Agrega el archivo `laliga.svg` en la carpeta `public`.
- Actualiza el componente principal para usar la nueva imagen de LaLiga en la sección de historias de éxito.

## Testing
- `npm test` (falta script de pruebas)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae223a54c8833085c164a2f8a136ef