### PR TITLE
feat: load google analytics id from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Google Analytics measurement ID
+VITE_GA_ID=G-XXXXXXXXXX

--- a/README.md
+++ b/README.md
@@ -81,4 +81,4 @@ and set your measurement ID:
 VITE_GA_ID=G-XXXXXXXXXX
 ```
 
-The `index.html` file will load the Google tag using this value.
+The app dynamically loads the Google tag in `src/main.tsx` using this value.

--- a/index.html
+++ b/index.html
@@ -23,19 +23,6 @@
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
 
-    <!-- Google tag (gtag.js) -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=%VITE_GA_ID%"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-      gtag("config", "%VITE_GA_ID%");
-    </script>
   </head>
 
   <body>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,24 @@
+declare global {
+  interface Window {
+    dataLayer: unknown[]
+  }
+}
+
+export function initGA(): void {
+  const gaId = import.meta.env.VITE_GA_ID
+  if (!gaId) return
+
+  // Load the Google Analytics script dynamically
+  const script = document.createElement('script')
+  script.async = true
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${gaId}`
+  document.head.appendChild(script)
+
+  window.dataLayer = window.dataLayer || []
+  function gtag(...args: unknown[]): void {
+    window.dataLayer.push(args)
+  }
+
+  gtag('js', new Date())
+  gtag('config', gaId)
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,7 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { initGA } from './lib/analytics'
 
-createRoot(document.getElementById("root")!).render(<App />);
+initGA()
+createRoot(document.getElementById('root')!).render(<App />)


### PR DESCRIPTION
## Summary
- load Google Analytics tag at runtime using VITE_GA_ID
- document env variable and provide example file

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1f1572cb88330a79bce486770e577