### PR TITLE
chore: remove env-based analytics loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,8 @@ To connect a domain, navigate to Project > Settings > Domains and click Connect 
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
 
-## Google Analytics
+## Google Tag Manager
 
-To track visits with Google Analytics 4, create an `.env` file in the project root
-and set your measurement ID:
-
-```bash
-VITE_GA_ID=G-XXXXXXXXXX
-```
-
-The `index.html` file will load the Google tag using this value.
+The app includes the Google Tag Manager snippet in `index.html`. If you need to
+use a different container, replace the `GTM-NPNKZ782` ID in that file with your
+own.

--- a/index.html
+++ b/index.html
@@ -23,19 +23,6 @@
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
 
-    <!-- Google tag (gtag.js) -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=%VITE_GA_ID%"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-      gtag("config", "%VITE_GA_ID%");
-    </script>
   </head>
 
   <body>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,4 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
-
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById('root')!).render(<App />)


### PR DESCRIPTION
## Summary
- remove GA loader and initialization code
- document and rely on static Google Tag Manager snippet

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1f1572cb88330a79bce486770e577